### PR TITLE
Add Google Talent API fallback for job crawling

### DIFF
--- a/src/lib/talent.ts
+++ b/src/lib/talent.ts
@@ -137,7 +137,7 @@ export async function searchJobWithTalentApi(env: TalentEnv, jobTitle: string, c
 
     const data = await res.json();
     const matched = data.jobs?.[0]?.job;
-    if (!matched) {
+    if (!matched || !matched.applicationInfo?.uris?.[0]) {
       return null;
     }
 

--- a/src/lib/talent.ts
+++ b/src/lib/talent.ts
@@ -147,7 +147,7 @@ export async function searchJobWithTalentApi(env: TalentEnv, jobTitle: string, c
       url: matched.applicationInfo?.uris?.[0] || '',
       location: matched.addresses?.[0],
       description_md: matched.description,
-      source: 'SCRAPED',
+      source: 'TALENT_API',
     };
     return job;
   } catch (err) {

--- a/src/lib/talent.ts
+++ b/src/lib/talent.ts
@@ -1,0 +1,158 @@
+import type { Job } from './types';
+
+export interface TalentEnv {
+  GCP_PROJECT_ID: string;
+  GCP_SERVICE_ACCOUNT_JSON: string;
+  GCP_TENANT_ID?: string;
+  USAGE_TRACKER: KVNamespace;
+}
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const TALENT_SCOPE = 'https://www.googleapis.com/auth/jobs';
+
+function base64url(input: ArrayBuffer | string): string {
+  const bytes = typeof input === 'string'
+    ? new TextEncoder().encode(input)
+    : new Uint8Array(input);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const b64 = pem.replace(/-----[^-]+-----/g, '').replace(/\s+/g, '');
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+async function getAccessToken(env: TalentEnv): Promise<string> {
+  const serviceAccount = JSON.parse(env.GCP_SERVICE_ACCOUNT_JSON);
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = {
+    iss: serviceAccount.client_email,
+    scope: TALENT_SCOPE,
+    aud: TOKEN_URL,
+    iat: now,
+    exp: now + 3600,
+  };
+
+  const encodedHeader = base64url(JSON.stringify(header));
+  const encodedPayload = base64url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const keyData = pemToArrayBuffer(serviceAccount.private_key);
+  const cryptoKey = await crypto.subtle.importKey(
+    'pkcs8',
+    keyData,
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: 'SHA-256',
+    },
+    false,
+    ['sign']
+  );
+
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    cryptoKey,
+    new TextEncoder().encode(signingInput)
+  );
+  const jwt = `${signingInput}.${base64url(signature)}`;
+
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion: jwt,
+  });
+
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+
+  if (!res.ok) {
+    console.error('Failed to obtain access token', res.status, await res.text());
+    throw new Error('Failed to obtain access token');
+  }
+
+  const data = await res.json();
+  return data.access_token as string;
+}
+
+async function checkAndIncrementUsage(env: TalentEnv): Promise<boolean> {
+  const now = new Date();
+  const key = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+  const current = parseInt((await env.USAGE_TRACKER.get(key)) || '0', 10);
+  if (current >= 10000) {
+    return false;
+  }
+  await env.USAGE_TRACKER.put(key, String(current + 1));
+  return true;
+}
+
+export async function searchJobWithTalentApi(env: TalentEnv, jobTitle: string, companyName: string): Promise<Job | null> {
+  const allowed = await checkAndIncrementUsage(env);
+  if (!allowed) {
+    console.warn('Talent API monthly usage limit reached');
+    return null;
+  }
+
+  try {
+    const accessToken = await getAccessToken(env);
+    const tenantPath = env.GCP_TENANT_ID ? `/tenants/${env.GCP_TENANT_ID}` : '';
+    const url = `https://jobs.googleapis.com/v4/projects/${env.GCP_PROJECT_ID}${tenantPath}/jobs:search`;
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        jobQuery: {
+          title: jobTitle,
+          companyDisplayName: companyName,
+        },
+        searchMode: 'JOB_SEARCH',
+        requestMetadata: {
+          domain: 'example.com',
+          sessionId: crypto.randomUUID(),
+          userId: 'worker',
+        },
+      }),
+    });
+
+    if (!res.ok) {
+      console.error('Talent API search failed', res.status, await res.text());
+      return null;
+    }
+
+    const data = await res.json();
+    const matched = data.jobs?.[0]?.job;
+    if (!matched) {
+      return null;
+    }
+
+    const job: Job = {
+      title: matched.title,
+      company: matched.companyDisplayName || companyName,
+      url: matched.applicationInfo?.uris?.[0] || '',
+      location: matched.addresses?.[0],
+      description_md: matched.description,
+      source: 'SCRAPED',
+    };
+    return job;
+  } catch (err) {
+    console.error('Talent API integration error', err);
+    return null;
+  }
+}
+

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -117,6 +117,32 @@ export interface EmailLog {
   status: 'pending' | 'processed' | 'failed';
 }
 
+export interface EmailInsights {
+  newJobs: Array<{
+    title: string;
+    company: string;
+    location?: string;
+    url: string;
+    posted_at: string;
+  }>;
+  jobChanges: Array<{
+    title: string;
+    company: string;
+    change_summary: string;
+    url: string;
+  }>;
+  statistics: {
+    totalJobs: number;
+    newJobsLastPeriod: number;
+    roleStats: Array<{
+      role: string;
+      count: number;
+      avgMinSalary?: number;
+      avgMaxSalary?: number;
+    }>;
+  };
+}
+
 // Job History Management Types
 export interface ApplicantProfile {
   id?: string;

--- a/src/routes/email.ts
+++ b/src/routes/email.ts
@@ -2,8 +2,8 @@
  * Email route handlers for job alert processing and insights reporting.
  */
 
-import { parseEmailFromRequest, extractJobInfo, formatInsightsEmail, EmailInsights, generateEmailInsights, sendInsightsEmail } from '../lib/email';
-import { Job, EmailLog, EmailConfig } from '../lib/types';
+import { parseEmailFromRequest, extractJobInfo, formatInsightsEmail, generateEmailInsights, sendInsightsEmail } from '../lib/email';
+import type { Job, EmailLog, EmailConfig, EmailInsights } from '../lib/types';
 import { crawlJob } from '../lib/crawl';
 import { saveJob } from '../lib/storage';
 
@@ -25,7 +25,7 @@ export async function handleEmailReceived(request: Request, env: any): Promise<R
 
     // Extract job information from email content
     const content = email.html || email.text || '';
-    const jobInfo = extractJobInfo(content);
+    const jobInfo = await extractJobInfo(env, content);
     
     console.log(`Extracted ${jobInfo.length} job links from email`);
 
@@ -45,8 +45,8 @@ export async function handleEmailReceived(request: Request, env: any): Promise<R
       try {
         console.log(`Processing job URL: ${job.url}`);
         
-        // Crawl and extract job data
-        const jobData = await crawlJob(env, job.url);
+        // Pass job title and company to the crawler for the fallback mechanism
+        const jobData = await crawlJob(env, job.url, undefined, job.title, job.company);
         
         if (jobData) {
           // Merge extracted info with crawled data

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,6 +18,11 @@ database_id = "11092798-a3d9-44b8-be5f-1835c0027887"
 binding = "KV"
 id = "5e60b00818e9448b8f965af0fc96d39a"
 
+[[kv_namespaces]]
+binding = "USAGE_TRACKER"
+id = "d78887786a634316a921a869c2e406e8"
+preview_id = "0900decc2f2043f4a5591eda43562065"
+
 [[r2_buckets]]
 binding = "R2"
 bucket_name = "job-scraper"


### PR DESCRIPTION
## Summary
- add Google Talent Solution API module with JWT auth and monthly usage tracking
- use Talent API as fallback when browser rendering fails
- pass job title and company from email route
- configure KV namespace for API usage tracking
- extract job details from emails using Workers AI for improved fallback
- centralize EmailInsights type and restore concise worker configuration

## Testing
- `pnpm typecheck` *(fails: Property 'url' is missing in type 'Record<string, unknown>' but required in type 'Job', and other existing issues in storage.ts, talent.ts, tracking.ts, workflows.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a6d335a4832eaac0a94b533befdc